### PR TITLE
Allow for traces which have some debug information already.

### DIFF
--- a/kptrace
+++ b/kptrace
@@ -85,6 +85,8 @@ class PanicReport:
             if found_backtrace_label:
                 if re.match(".*0x.{16} : 0x.{16}.*", line):
                     addr = line[20:].strip()
+                    if " " in addr:
+                        addr = addr[:addr.find(" ")].strip()
                     result.addresses.append(addr)
                 else:
                     break;


### PR DESCRIPTION
If you have a trace that was running a debug version of the kext, some of the symbols are already in the trace.  This patch allows for that format as well.